### PR TITLE
documentation fix - modelTableFk naming

### DIFF
--- a/ETaggableBehavior.php
+++ b/ETaggableBehavior.php
@@ -38,7 +38,7 @@ class ETaggableBehavior extends CActiveRecordBehavior {
 	 */
 	public $tagTableCount;
 	/**
-	 * @var string binding table model FK name.
+	 * @var string binding table model FK field name.
 	 * Defaults to `{model table name with first lowercased letter}Id`.
 	 */
 	public $modelTableFk;

--- a/readme_en.txt
+++ b/readme_en.txt
@@ -21,7 +21,7 @@ function behaviors() {
             // Cross-table that stores tag-model connections.
             // By default it's your_model_tableTag
             'tagBindingTable' => 'PostTag',
-            // Foreign key in cross-table.
+            // Foreign key field field in cross-table.
             // By default it's your_model_tableId
             'modelTableFk' => 'post_id',
             // Tag table PK field


### PR DESCRIPTION
modelTableFk is documented as "string binding table model FK name."
it should be
modelTableFk is documented as "string binding table model FK field name."
FK name is the name of the foreign-key constraint itself which doesn't make too much sense and is confusing.
