### PR TITLE
Changes for getAllTagsWithModelsCount

### DIFF
--- a/ETaggableBehavior.php
+++ b/ETaggableBehavior.php
@@ -586,7 +586,7 @@ class ETaggableBehavior extends CActiveRecordBehavior {
 			if($this->getScopeCriteria())
 				$tagsCriteria->mergeWith($this->getScopeCriteria());
 
-            
+
 			$tags = $builder->createFindCommand($this->tagTable, $tagsCriteria)->queryAll();
 
 			$this->cache->set('Taggable'.$this->getOwner()->tableName().'AllWithCount', $tags);


### PR DESCRIPTION
7505283 if use count as column missed join for tagBindingTable,

if use empty tag then it will find all with tag='', and find nothing. (this case useful for me, but i not sure that it will be advisable for all)

sorry, i dont know how pull only one change, but they in same file and i think its not possible to send only 7505283 changes
