### PR TITLE
Fixes for setTags() and empty tags

### DIFF
--- a/ETaggableBehavior.php
+++ b/ETaggableBehavior.php
@@ -143,6 +143,8 @@ class ETaggableBehavior extends CActiveRecordBehavior {
 	 * @return void
 	 */
 	public function setTags($tags) {
+		$this->loadTags();
+		
 		$tags = $this->toTagsArray($tags);
 		$this->tags = array_unique($tags);
 
@@ -283,6 +285,7 @@ class ETaggableBehavior extends CActiveRecordBehavior {
 		}
 
 		array_walk($tags, array($this, 'trim'));
+		$tags = array_filter($tags, 'strlen');
 		return $tags;
 	}
 	/**
@@ -355,7 +358,7 @@ class ETaggableBehavior extends CActiveRecordBehavior {
 			// add new tag bindings and tags if there are any
 			if(!empty($this->tags)){
 				foreach($this->tags as $tag){
-					if(empty($tag)) return;
+					if(empty($tag)) continue;
 
 					// try to get existing tag
 					$findCriteria = new CDbCriteria(array(

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+1.6?
+---
+- Fixed: setTags() did not call loadTags(). Furtheron, neededSave() would re-save even though no tags had changed, or not save when empty setTags(array()) was called. (marcovtwout)
+- Fixed: in for loop while saving in afterSave(), don't abort whem empty tag is found (marcovtwout)
+- Remove empty tags before handling (marcovtwout)
+
 1.5
 ---
 - updateCount now uses proper PK name (RSol)


### PR DESCRIPTION
FIX: setTags() did not call loadTags(). Furtheron, neededSave() would
re-save even though no tags had changed, or not save when empty
setTags(array()) was called.

FIX: in for loop while saving in afterSave(), when empty tag was found,
continue instead of aborting.

CHG: remove empty tags before handling
